### PR TITLE
feat: add elevenlabs key reference handling

### DIFF
--- a/nodes/TelnyxAi/Descriptions/utils.ts
+++ b/nodes/TelnyxAi/Descriptions/utils.ts
@@ -7,12 +7,17 @@ import { ITelnyxConversationsResponse } from '../@types/conversations';
 
 export const listSearch = {
 	async listVoices(this: ILoadOptionsFunctions): Promise<INodeListSearchResult> {
+		const elevenLabsApiKeyRef = this.getNodeParameter('elevenlabs_api_key_ref_2', '') as string;
+
 		const voicesResponse = (await this.helpers.httpRequestWithAuthentication.call(
 			this,
 			'telnyxApi',
 			{
 				method: 'GET',
 				url: 'https://api.telnyx.com/v2/text-to-speech/voices',
+				qs: {
+					elevenlabs_api_key_ref: elevenLabsApiKeyRef,
+				},
 			},
 		)) as ITelnyxVoiceResponse;
 

--- a/nodes/TelnyxAi/Descriptions/voice.ts
+++ b/nodes/TelnyxAi/Descriptions/voice.ts
@@ -82,6 +82,53 @@ export const VoiceOperations: INodeProperties[] = [
 ];
 
 export const VoiceFields: INodeProperties[] = [
+	{
+		displayName: 'Provider',
+		name: 'provider',
+		type: 'options',
+		options: [
+			{ name: 'AWS', value: 'aws' },
+			{ name: 'Azure', value: 'azure' },
+			{ name: 'ElevenLabs', value: 'elevenlabs' },
+			{ name: 'Telnyx', value: 'telnyx' },
+		],
+		default: 'telnyx',
+		description: 'Filter voices by provider',
+		displayOptions: {
+			show: {
+				resource: ['voice'],
+				operation: ['getAll'],
+			},
+		},
+		routing: {
+			send: {
+				type: 'query',
+				property: 'provider',
+			},
+		},
+	},
+	{
+		displayName: 'ElevenLabs API Key Reference',
+		name: 'elevenlabs_api_key_ref',
+		type: 'string',
+		default: '',
+		required: true,
+		description:
+			'Reference to your ElevenLabs API key stored in Integration Secrets on Telnyx Portal',
+		displayOptions: {
+			show: {
+				resource: ['voice'],
+				operation: ['getAll'],
+				provider: ['elevenlabs'],
+			},
+		},
+		routing: {
+			send: {
+				type: 'query',
+				property: 'elevenlabs_api_key_ref',
+			},
+		},
+	},
 	// Text to Speech
 	{
 		displayName: 'Voice',
@@ -94,6 +141,12 @@ export const VoiceFields: INodeProperties[] = [
 			show: {
 				resource: ['voice'],
 				operation: ['textToSpeech'],
+			},
+		},
+		disabledOptions: {
+			show: {
+				includeElevenLabsVoices: [true],
+				elevenlabs_api_key_ref_2: [''],
 			},
 		},
 		modes: [
@@ -117,6 +170,35 @@ export const VoiceFields: INodeProperties[] = [
 			send: {
 				type: 'body',
 				property: 'voice',
+			},
+		},
+	},
+	{
+		displayName: 'Include ElevenLabs Voices',
+		name: 'includeElevenLabsVoices',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to include ElevenLabs voices in the response',
+		displayOptions: {
+			show: {
+				resource: ['voice'],
+				operation: ['textToSpeech'],
+			},
+		},
+	},
+	{
+		displayName: 'ElevenLabs API Key Reference',
+		name: 'elevenlabs_api_key_ref_2',
+		type: 'string',
+		default: '',
+		required: true,
+		description:
+			'Reference to your ElevenLabs API key stored in Integration Secrets on Telnyx Portal',
+		displayOptions: {
+			show: {
+				resource: ['voice'],
+				operation: ['textToSpeech'],
+				includeElevenLabsVoices: [true],
 			},
 		},
 	},


### PR DESCRIPTION
This pull request introduces support for ElevenLabs as a voice provider in the Telnyx AI integration. It adds new configuration options, API key handling, and functionality to include ElevenLabs voices in the response. Below are the key changes grouped by theme:

### Integration with ElevenLabs:

* Added a query parameter `elevenlabs_api_key_ref` to the `listVoices` method in `utils.ts` for passing the ElevenLabs API key reference when fetching voices.

* Introduced a new `provider` option in `VoiceFields` to filter voices by provider, including support for ElevenLabs.

### Configuration for ElevenLabs API:

* Added a new field `ElevenLabs API Key Reference` in `VoiceFields` for storing the API key reference required for ElevenLabs integration. This field is displayed when the provider is set to ElevenLabs.

* Added a boolean field `Include ElevenLabs Voices` in `VoiceFields` to allow users to include ElevenLabs voices in the response for the `textToSpeech` operation.

* Added a second `ElevenLabs API Key Reference` field in `VoiceFields` specifically for the `textToSpeech` operation, displayed only when `Include ElevenLabs Voices` is enabled.